### PR TITLE
[RW-857] Theming the chat

### DIFF
--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -72,11 +72,11 @@
   display: flex;
   flex-flow: column nowrap;
   justify-content: space-between;
+  padding-block-start: 1rem;
 }
 
 .ocha-ai-chat-chat-form [data-drupal-selector="edit-advanced"] {
   flex: 0 0 auto;
-  display: none;
 }
 
 .ocha-ai-chat-chat-form [data-drupal-selector="edit-chat"] {

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -215,6 +215,10 @@ button doesn't overlay any text */
   }
 }
 
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__q--loading {
+  margin-block-end: 2rem;
+}
+
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__a,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__refs {
   margin-block-start: 0.5rem;
@@ -286,7 +290,12 @@ button doesn't overlay any text */
 .ocha-ai-chat-chat-form .ajax-progress {
   position: absolute;
   top: -2.5rem;
-  right: 0;
+  right: 21px;
   background: rgba(255, 255, 255, 0.5);
   border-radius: 3px;
+
+  [dir="rtl"] & {
+    right: initial;
+    left: 21px;
+  }
 }

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -1,5 +1,6 @@
 :root {
   --oaic-outline: 2px; /* CD dependency */
+  --oaic-textarea-height: 76px;
 }
 
 /**
@@ -110,16 +111,24 @@ has the intended effect if the parent is flex with flex-direction:column */
 
 /* lock size of input section so it hugs the bottom of the frame */
 .ocha-ai-chat-chat-form .form-item-question {
-  flex: 0 0 auto;
+  flex: 0 0 var(--oaic-textarea-height);
 }
 
-/* Button is overlaid on top of text input. The input has passing to ensure this
+/* Button is overlaid on top of text input. The input has padding to ensure this
 button doesn't overlay any text */
 .ocha-ai-chat-chat-form [data-drupal-selector="edit-actions"] {
   position: absolute;
   bottom: 0;
+  right: 0;
   z-index: 100;
-  text-align: end;
+  min-width: initial;
+  width: min-content;
+  height: calc(var(--oaic-textarea-height) - 2px);
+
+  [dir="rtl"] & {
+    right: unset;
+    left: 0;
+  }
 }
 
 
@@ -254,7 +263,30 @@ button doesn't overlay any text */
 /**
  * User input area
  */
-[data-drupal-selector="edit-question"] {
+/* Textarea */
+.ocha-ai-chat-chat-form [data-drupal-selector="edit-question"] {
   /* The 'Ask' button takes up this space, so we pad the textarea. */
   padding-inline-end: 4rem;
+  resize: none;
+  height: var(--oaic-textarea-height);
+}
+
+/* Submit button */
+.ocha-ai-chat-chat-form .cd-button[data-drupal-selector="edit-submit"] {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  height: calc(100% + 2px);
+  margin-inline-end: 0;
+  border-radius: 0;
+  background: var(--brand-primary);
+}
+
+/* Ajax throbber */
+.ocha-ai-chat-chat-form .ajax-progress {
+  position: absolute;
+  top: -2.5rem;
+  right: 0;
+  background: rgba(255, 255, 255, 0.5);
+  border-radius: 3px;
 }

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -145,7 +145,7 @@
  *
  * Each Q/A results in a chat-like set of bubbles. Think of SMS or WhatsApp.
  */
-.ocha-ai-chat-chat-form .ocha-ai-chat-result dl {
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat {
   display: flex;
   flex-flow: column nowrap;
   margin-top: 1rem;
@@ -155,15 +155,15 @@
   margin: 0;
 }
 
-.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_q,
-.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_a,
-.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_refs {
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__q,
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__a,
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__refs {
   padding: 6px 12px;
   border-radius: 5px;
   position: relative;
 }
 
-.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_q {
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__q {
   margin-inline-start: 2rem;
   text-align: end;
   color: white;
@@ -184,8 +184,8 @@
   }
 }
 
-.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_a,
-.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_refs {
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__a,
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__refs {
   margin-block-start: 0.5rem;
   margin-inline-end: 2rem;
   text-align: start;
@@ -207,7 +207,7 @@
   }
 }
 
-.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_refs dt {
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__refs dt {
   font-weight: 700;
 }
 

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -1,6 +1,7 @@
 .ocha-ai-chat-chat-form-wrapper {
-  margin-top: 2rem;
+  margin-block-start: 2rem;
 }
+
 .ocha-ai-chat-chat-form details {
   display: block;
   padding: 12px;
@@ -9,10 +10,12 @@
   background-color: #fff;
   box-shadow: rgba(0, 0, 0, 0.1) 0 2px 4px 0;
 }
+
 .ocha-ai-chat-chat-form details > summary {
   cursor: pointer;
   font-weight: bold;
 }
+
 .ocha-ai-chat-chat-form details[open] > summary {
   margin-bottom: 12px;
 }
@@ -21,40 +24,90 @@
   word-break: break-all;
 }
 
-.ocha-ai-chat-chat-form .ocha-ai-chat-result {
-  margin-top: 1rem;
-  padding: 12px;
-  border: 1px solid black;
-  border-radius: 6px;
-}
 .ocha-ai-chat-chat-form .ocha-ai-chat-result + .ocha-ai-chat-result {
+  margin-block-start: 1rem;
+}
+
+.ocha-ai-chat-chat-form .ocha-ai-chat-result dl {
+  display: flex;
+  flex-flow: column nowrap;
   margin-top: 1rem;
 }
-.ocha-ai-chat-chat-form .ocha-ai-chat-result:last-child {
-  border: 4px solid #82b5e9;
-}
-.ocha-ai-chat-chat-form .ocha-ai-chat-result dl {
-  margin-top: 0;
-}
-.ocha-ai-chat-chat-form .ocha-ai-chat-result dt {
-  font-weight: bold;
-}
+
 .ocha-ai-chat-chat-form .ocha-ai-chat-result dd {
-  margin-left: 24px;
+  margin: 0;
+}
+
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_q,
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_a,
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_refs {
+  padding: 6px 12px;
+  border-radius: 5px;
+  position: relative;
+}
+
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_q {
+  margin-inline-start: 2rem;
+  text-align: end;
+  color: white;
+  background: var(--brand-primary);
+
+  /* TODO: RTL */
+  &::before {
+    display: block;
+    position: absolute;
+    right: -8px;
+    bottom: 6px;
+    content: '';
+    width: 0;
+    height: 0;
+    border-top: 8px solid transparent;
+    border-left: 10px solid var(--brand-primary);
+    border-bottom: 4px solid transparent;
+  }
+}
+
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_a,
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_refs {
+  margin-block-start: 0.5rem;
+  margin-inline-end: 2rem;
+  text-align: start;
+  color: #333;
+  background: var(--brand-grey);
+
+  /* TODO: RTL */
+  &::before {
+    display: block;
+    position: absolute;
+    left: -8px;
+    bottom: 6px;
+    content: '';
+    width: 0;
+    height: 0;
+    border-top: 8px solid transparent;
+    border-right: 10px solid var(--brand-grey);
+    border-bottom: 4px solid transparent;
+  }
+}
+
+.ocha-ai-chat-chat-form .ocha-ai-chat-result .chat_refs dt {
+  font-weight: 700;
 }
 
 .ocha-ai-chat-chat-form .ocha-ai-chat-reference-list {
-  padding-left: 0;
+  list-style-type: none;
 }
+
 .ocha-ai-chat-chat-form .ocha-ai-chat-reference {
   display: inline;
   margin: 0;
   padding: 0;
-  list-style-type: none;
 }
+
 .ocha-ai-chat-chat-form .ocha-ai-chat-reference li {
   display: inline;
 }
+
 .ocha-ai-chat-chat-form .ocha-ai-chat-reference li:not(:last-child)::after {
   content: ", ";
 }
@@ -62,6 +115,7 @@
 .ocha-ai-chat-chat-form input[type="number"] {
   max-width: 10ch;
 }
+
 .ocha-ai-chat-chat-form input[type="text"] {
   max-width: 100%;
 }
@@ -70,18 +124,23 @@
 .ocha-ai-chat-popup {
   background-color: white;
 }
+
 .ocha-ai-chat-popup *:has( ~ main) {
   display: none;
 }
+
 .ocha-ai-chat-popup main ~ * {
   display: none;
 }
+
 .ocha-ai-chat-popup body > *:not(:has(main)) {
   display: none;
 }
+
 .ocha-ai-chat-popup main {
   padding: 24px;
 }
+
 .ocha-ai-chat-popup main h1 {
   font-size: 1.5rem;
 }

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -1,5 +1,72 @@
+:root {
+  --oaic-padding: 24px;
+  --oaic-outline: 2px; /* CD dependency */
+}
+
+/**
+ * Page layout reset.
+ *
+ * Hide everything except the chat form content. These rules exist in the module
+ * so that individual sub-theme implementations don't have to override the page
+ * template and manually zero-out the CD Header/Footer.
+ */
+.ocha-ai-chat-popup {
+  background-color: white;
+}
+
+.ocha-ai-chat-popup *:has( ~ main) {
+  display: none;
+}
+
+.ocha-ai-chat-popup main ~ * {
+  display: none;
+}
+
+.ocha-ai-chat-popup body > *:not(:has(main)) {
+  display: none;
+}
+
+.ocha-ai-chat-popup main h1 {
+  font-size: 1.5rem;
+}
+
+/**
+ * Page layout
+ */
+.ocha-ai-chat,
+.ocha-ai-chat main,
+.ocha-ai-chat .region,
+.ocha-ai-chat__content {
+  height: 100%;
+}
+
+.ocha-ai-chat #main-content {
+  padding-block: 0;
+  padding-inline: var(--oaic-padding);
+}
+
 .ocha-ai-chat-chat-form-wrapper {
   margin-block-start: 2rem;
+}
+
+/**
+ * Title / Heading area
+ */
+.ocha-ai-chat .rw-page-title {
+  margin-block: 0;
+  margin-inline: calc(-1 * var(--oaic-padding));
+  padding: 12px;
+  background: var(--brand-primary);
+  color: var(--cd-white);
+  border-bottom: 0;
+}
+
+
+/**
+ * Chat form
+ */
+.ocha-ai-chat-chat-form {
+  position: relative;
 }
 
 .ocha-ai-chat-chat-form details {
@@ -118,29 +185,4 @@
 
 .ocha-ai-chat-chat-form input[type="text"] {
   max-width: 100%;
-}
-
-/* Hide everything except the chat form content. */
-.ocha-ai-chat-popup {
-  background-color: white;
-}
-
-.ocha-ai-chat-popup *:has( ~ main) {
-  display: none;
-}
-
-.ocha-ai-chat-popup main ~ * {
-  display: none;
-}
-
-.ocha-ai-chat-popup body > *:not(:has(main)) {
-  display: none;
-}
-
-.ocha-ai-chat-popup main {
-  padding: 24px;
-}
-
-.ocha-ai-chat-popup main h1 {
-  font-size: 1.5rem;
 }

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -79,17 +79,42 @@
   flex: 0 0 auto;
 }
 
+/* This element provides the top-level layout for the chat content. */
 .ocha-ai-chat-chat-form [data-drupal-selector="edit-chat"] {
   flex: 1 1 100%;
-  padding: 0 16px 12px;
-  overflow-y: scroll;
-  overflow-x: visible;
+  padding-block-start: 1rem;
+  overflow-y: hidden;
 }
 
+/* Actual chat container. This is the direct parent of the chat content. */
+.ocha-ai-chat-chat-form [data-drupal-selector="edit-chat"] .fieldset-wrapper {
+  height: 100%;
+  display: flex;
+  flex-flow: column nowrap;
+  padding: 0 16px 12px;
+  overflow-x: hidden;
+
+  /* In a perfect world, we'd set the following to bottom-align the chat content
+  as it appears in the DOM. However, the CSS Spec essentially forbids overflow
+  scrolling once we set this property. Go ahead, try it for yourself. */
+  /* justify-content: flex-end; */
+}
+
+/* The instructions margins provide crucial styles to bottom-align content so
+they are included in this section instead of general styling. Auto-margin only
+has the intended effect if the parent is flex with flex-direction:column */
+.ocha-ai-chat-chat-form__instructions {
+  margin-block-start: auto;
+  padding-block-start: 1rem;
+}
+
+/* lock size of input section so it hugs the bottom of the frame */
 .ocha-ai-chat-chat-form .form-item-question {
   flex: 0 0 auto;
 }
 
+/* Button is overlaid on top of text input. The input has passing to ensure this
+button doesn't overlay any text */
 .ocha-ai-chat-chat-form [data-drupal-selector="edit-actions"] {
   position: absolute;
   bottom: 0;
@@ -101,10 +126,6 @@
 /**
  * Chat form styles
  */
-.ocha-ai-chat-chat-form__instructions {
-  padding-block-start: 1rem;
-}
-
 .ocha-ai-chat-chat-form details {
   display: block;
   margin: 0 12px;
@@ -148,7 +169,8 @@
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat {
   display: flex;
   flex-flow: column nowrap;
-  margin-top: 1rem;
+  margin-block-start: 1rem;
+  margin-block-end: 0;
 }
 
 .ocha-ai-chat-chat-form .ocha-ai-chat-result dd {
@@ -232,3 +254,7 @@
 /**
  * User input area
  */
+[data-drupal-selector="edit-question"] {
+  /* The 'Ask' button takes up this space, so we pad the textarea. */
+  padding-inline-end: 4rem;
+}

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -83,7 +83,6 @@
 /* This element provides the top-level layout for the chat content. */
 .ocha-ai-chat-chat-form [data-drupal-selector="edit-chat"] {
   flex: 1 1 100%;
-  padding-block-start: 1rem;
   overflow-y: hidden;
 }
 
@@ -92,14 +91,10 @@
   height: 100%;
   display: flex;
   flex-flow: column nowrap;
-  padding: 0 16px 12px;
+  padding-inline: 16px;
+  padding-block-end: 16px;
   overflow-x: hidden;
   overflow-y: scroll;
-
-  /* In a perfect world, we'd set the following to bottom-align the chat content
-  as it appears in the DOM. However, the CSS Spec essentially forbids overflow
-  scrolling once we set this property. Go ahead, try it for yourself. */
-  /* justify-content: flex-end; */
 }
 
 /* The instructions margins provide crucial styles to bottom-align content so
@@ -107,7 +102,7 @@ they are included in this section instead of general styling. Auto-margin only
 has the intended effect if the parent is flex with flex-direction:column */
 .ocha-ai-chat-chat-form__instructions {
   margin-block-start: auto;
-  padding-block-start: 1rem;
+  padding-block: 1rem;
 }
 
 /* lock size of input section so it hugs the bottom of the frame */

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -1,5 +1,4 @@
 :root {
-  --oaic-padding: 24px;
   --oaic-outline: 2px; /* CD dependency */
 }
 
@@ -41,20 +40,19 @@
 }
 
 .ocha-ai-chat #main-content {
-  padding-block: 0;
-  padding-inline: var(--oaic-padding);
+  padding: 0;
 }
 
 .ocha-ai-chat-chat-form-wrapper {
-  margin-block-start: 2rem;
+  /* height has to take the title into account. */
+  height: calc(100% - 1.5rem - 24px - 7px); /* TODO: 7px is a magic number */
 }
 
 /**
  * Title / Heading area
  */
 .ocha-ai-chat .rw-page-title {
-  margin-block: 0;
-  margin-inline: calc(-1 * var(--oaic-padding));
+  margin: 0;
   padding: 12px;
   background: var(--brand-primary);
   color: var(--cd-white);
@@ -63,19 +61,54 @@
 
 
 /**
- * Chat form
+ * Chat form layout
  */
-.ocha-ai-chat-chat-form {
+/* duplicate class to override CD defaults */
+.ocha-ai-chat-chat-form.ocha-ai-chat-chat-form {
+  --cd-flow-space: 0;
+
+  height: 100%;
   position: relative;
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: space-between;
 }
 
+.ocha-ai-chat-chat-form [data-drupal-selector="edit-advanced"] {
+  flex: 0 0 auto;
+  display: none;
+}
+
+.ocha-ai-chat-chat-form [data-drupal-selector="edit-chat"] {
+  flex: 1 1 100%;
+  padding: 0 16px 12px;
+  overflow-y: scroll;
+  overflow-x: visible;
+}
+
+.ocha-ai-chat-chat-form .form-item-question {
+  flex: 0 0 auto;
+}
+
+.ocha-ai-chat-chat-form [data-drupal-selector="edit-actions"] {
+  position: absolute;
+  bottom: 0;
+  z-index: 100;
+  text-align: end;
+}
+
+
+/**
+ * Chat form styles
+ */
 .ocha-ai-chat-chat-form details {
   display: block;
+  margin: 0 12px;
   padding: 12px;
   border: 1px solid #ddd;
   border-radius: 3px;
   background-color: #fff;
-  box-shadow: rgba(0, 0, 0, 0.1) 0 2px 4px 0;
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
 }
 
 .ocha-ai-chat-chat-form details > summary {
@@ -95,6 +128,19 @@
   margin-block-start: 1rem;
 }
 
+.ocha-ai-chat-chat-form input[type="number"] {
+  max-width: 10ch;
+}
+
+.ocha-ai-chat-chat-form input[type="text"] {
+  max-width: 100%;
+}
+
+/**
+ * Q/A history
+ *
+ * Each Q/A results in a chat-like set of bubbles. Think of SMS or WhatsApp.
+ */
 .ocha-ai-chat-chat-form .ocha-ai-chat-result dl {
   display: flex;
   flex-flow: column nowrap;
@@ -179,10 +225,6 @@
   content: ", ";
 }
 
-.ocha-ai-chat-chat-form input[type="number"] {
-  max-width: 10ch;
-}
-
-.ocha-ai-chat-chat-form input[type="text"] {
-  max-width: 100%;
-}
+/**
+ * User input area
+ */

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -1,6 +1,7 @@
 :root {
   --oaic-outline: 2px; /* CD dependency */
   --oaic-textarea-height: 76px;
+  --oaic-padding-block-start: 0px;
 }
 
 /**
@@ -91,6 +92,7 @@
   height: 100%;
   display: flex;
   flex-flow: column nowrap;
+  padding-block-start: var(--oaic-padding-block-start);
   padding-inline: 16px;
   padding-block-end: 16px;
   overflow-x: hidden;

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -94,6 +94,7 @@
   flex-flow: column nowrap;
   padding: 0 16px 12px;
   overflow-x: hidden;
+  overflow-y: scroll;
 
   /* In a perfect world, we'd set the following to bottom-align the chat content
   as it appears in the DOM. However, the CSS Spec essentially forbids overflow

--- a/components/chat-form/chat-form.css
+++ b/components/chat-form/chat-form.css
@@ -101,6 +101,10 @@
 /**
  * Chat form styles
  */
+.ocha-ai-chat-chat-form__instructions {
+  padding-block-start: 1rem;
+}
+
 .ocha-ai-chat-chat-form details {
   display: block;
   margin: 0 12px;

--- a/components/chat-form/chat-form.js
+++ b/components/chat-form/chat-form.js
@@ -35,7 +35,17 @@
       // Upate UI when submit is pressed. Each time ajax finishes, the
       // whole chat history will be re-inserted into the DOM. That means we can
       // temporarily inject whatever we like and it will get cleaned up for us.
-      function chatSend (event) {
+      function chatSend (ev) {
+        // First check the question textarea for a value. We don't want to act
+        // unless we have a value to send.
+        var questionValue = document.querySelector('[data-drupal-selector="edit-question"]').value;
+
+        // If we couldn't find a question, exit early.
+        if (!questionValue) {
+          ev.preventDefault();
+          return;
+        }
+
         var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
         var chatResult = Drupal.behaviors.ochaAiChatUtils.createElement('div', {
           'class': 'ocha-ai-chat-result',
@@ -49,7 +59,6 @@
         var questionDt = Drupal.behaviors.ochaAiChatUtils.createElement('dt', {
           'class': 'visually-hidden',
         }, 'Question');
-        var questionValue = document.querySelector('[data-drupal-selector="edit-question"]').value;
         var questionDd = Drupal.behaviors.ochaAiChatUtils.createElement('dd', {}, questionValue);
 
         // Prep all the DOM nodes for insertion.

--- a/components/chat-form/chat-form.js
+++ b/components/chat-form/chat-form.js
@@ -1,8 +1,8 @@
 (function () {
   'use strict';
 
-  // These variables need to survive in between executions of Drupal's `attach`
-  // method so we instantiate them outside the Behavior itself.
+  // Some data needs to survive between executions of Drupal's `attach` method
+  // so we instantiate it outside the Behavior itself.
   var oldScrollHeight;
 
   // Initialize. We do this outside Drupal.behaviors because it doesn't need to
@@ -14,9 +14,13 @@
       var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
       var submitButton = document.querySelector('[data-drupal-selector="edit-submit"]');
 
+      // Add padding equal to chat window so we can always scroll. We take 16px
+      // away to avoid overages due to padding-bottom.
+      var chatHeight = chatContainer.getBoundingClientRect().height - 16;
+      chatContainer.style.paddingBlockStart = chatHeight + 'px';
+
       // Do some calculations to decide where to start our smooth scroll.
       if (oldScrollHeight) {
-        var chatHeight = chatContainer.getBoundingClientRect().height;
         var smoothScrollStart = oldScrollHeight - chatHeight;
 
         // Jump to where the bottom of the previous container was before the DOM

--- a/components/chat-form/chat-form.js
+++ b/components/chat-form/chat-form.js
@@ -7,9 +7,55 @@
 
   Drupal.behaviors.ochaAiChatForm = {
     attach: function (context, settings) {
-      // Scroll to bottom of chat contents container.
       var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
+
+      // Scroll to bottom of chat container. We can't use smooth scrolling to
+      // create a convincing effect without storing and calculating the position
+      // from before the ajax submission, so we immediately set it to the bottom
+      // so that any new content is prominently visible neat the text input.
       chatContainer.scrollTop = chatContainer.scrollHeight;
+
+      // Custom actions when submit is pressed. Each time ajax finishes, the whole
+      // chat history will be re-rendered so we can temporarily inject whatever we
+      // like and it will get cleaned up.
+      var submitButton = document.querySelector('[data-drupal-selector="edit-submit"]');
+      // TODO: will this work on mobile or do we need to attach the listener to
+      // separate events? e.g. touchend
+      submitButton.addEventListener('mousedown', event => {
+        var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
+        var chatResult = Drupal.behaviors.ochaAiChatUtils.createElement('div', {
+          'class': 'ocha-ai-chat-result',
+        }, {});
+        var questionDl = Drupal.behaviors.ochaAiChatUtils.createElement('dl', {
+          'class': 'chat',
+        }, {});
+        var questionWrapper = Drupal.behaviors.ochaAiChatUtils.createElement('div', {
+          'class': 'chat__q chat__q--loading',
+        }, {});
+        var questionDt = Drupal.behaviors.ochaAiChatUtils.createElement('dt', {
+            'class': 'visually-hidden',
+          }, 'Question'
+        );
+        var questionValue = document.querySelector('[data-drupal-selector="edit-question"]').value;
+        var questionDd = Drupal.behaviors.ochaAiChatUtils.createElement('dd', {}, questionValue);
+
+        // Prep all the DOM nodes for insertion.
+        questionWrapper.append(questionDt);
+        questionWrapper.append(questionDd);
+        questionDl.append(questionWrapper);
+        chatResult.append(questionDl);
+
+        // Introduce a small delay before question gets inserted into DOM.
+        setTimeout(() => {
+          chatContainer.append(chatResult);
+
+          // In this instance we use smooth scrolling. It won't be smooth unless
+          // the continer can be scrolled to begin with, so in practice the
+          // first one never has a smooth scroll.
+          chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
+        }, 200);
+      });
     },
   };
+
 })();

--- a/components/chat-form/chat-form.js
+++ b/components/chat-form/chat-form.js
@@ -13,11 +13,7 @@
     attach: function (context, settings) {
       var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
       var submitButton = document.querySelector('[data-drupal-selector="edit-submit"]');
-
-      // Add padding equal to chat window so we can always scroll. We take 16px
-      // away to avoid overages due to padding-bottom.
-      var chatHeight = chatContainer.getBoundingClientRect().height - 16;
-      chatContainer.style.paddingBlockStart = chatHeight + 'px';
+      var chatHeight = this.padChatWindow();
 
       // Do some calculations to decide where to start our smooth scroll.
       if (oldScrollHeight) {
@@ -103,6 +99,24 @@
           chatSend(ev);
         }
       });
+
+      // Listen for window resizes and recalculate the amount of padding needed
+      // within the chat history.
+      window.addEventListener('resize', Drupal.debounce(this.padChatWindow, 33));
+    },
+
+    // Calculates the size of the chat window and adds padding to ensure there
+    // is always a scrollable area. This allows the smooth-scroll code to create
+    // the illusion of a chat UI like SMS or WhatsApp.
+    padChatWindow: function (ev) {
+      var chatContainerOuter = document.querySelector('[data-drupal-selector="edit-chat"]');
+      var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
+
+      // There's some bottom padding we have to subtract away.
+      var chatHeight = chatContainerOuter.getBoundingClientRect().height - 16;
+      chatContainer.style.setProperty('--oaic-padding-block-start', chatHeight + 'px');
+
+      return chatHeight;
     },
   };
 

--- a/components/chat-form/chat-form.js
+++ b/components/chat-form/chat-form.js
@@ -32,8 +32,8 @@
         chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
       }
 
-      // Upate UI when submit is pressed. Each time ajax finishes, the
-      // whole chat history will be re-inserted into the DOM. That means we can
+      // Upate UI when submit is pressed. Each time ajax finishes, the whole
+      // chat history will be re-inserted into the DOM. That means we can
       // temporarily inject whatever we like and it will get cleaned up for us.
       function chatSend (ev) {
         // First check the question textarea for a value. We don't want to act
@@ -72,8 +72,9 @@
           chatContainer.append(chatResult);
 
           // In this instance we use smooth scrolling. It won't be smooth unless
-          // the continer can be scrolled to begin with, so in practice the
-          // first one never has a smooth scroll.
+          // the continer can be scrolled to begin with, but if padding was able
+          // to be added when the window opened, then it should work from the
+          // very beginning of the chat history.
           chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
 
           // Store the scroll position so that we can attempt to smooth-scroll
@@ -82,7 +83,18 @@
         }, 200);
       };
 
-      // All the input modes!
+      // Check all the input modes and add our client-side effect.
+      //
+      // We use `mousedown` instead of `click` because the latter didn't seem to
+      // have any effect when testing. It's possible that Drupal stops event
+      // propagation, preventing a `click` from ever executing.
+      //
+      // Note: Drupal 10 has a bug that might seem like we introduced, but
+      // its behavior comes from core. Ajax event listeners use mousedown so
+      // forms will submit even when doing actions like right-click which aren't
+      // meant to submit the form.
+      //
+      // @see https://www.drupal.org/project/drupal/issues/2616184
       submitButton.addEventListener('touchend', chatSend);
       submitButton.addEventListener('mousedown', chatSend);
       submitButton.addEventListener('keydown', function(ev) {

--- a/components/chat-form/chat-form.js
+++ b/components/chat-form/chat-form.js
@@ -1,5 +1,15 @@
 (function () {
   'use strict';
 
+  // Initialize. We do this outside Drupal.behaviors because it doesn't need to
+  // run each time ajax gets called.
   window.parent.postMessage('ready', window.origin);
+
+  Drupal.behaviors.ochaAiChatForm = {
+    attach: function (context, settings) {
+      // Scroll to bottom of chat contents container.
+      var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
+      chatContainer.scrollTop = chatContainer.scrollHeight;
+    },
+  };
 })();

--- a/components/chat-form/chat-form.js
+++ b/components/chat-form/chat-form.js
@@ -1,6 +1,10 @@
 (function () {
   'use strict';
 
+  // These variables need to survive in between executions of Drupal's `attach`
+  // method so we instantiate them outside the Behavior itself.
+  var oldScrollHeight;
+
   // Initialize. We do this outside Drupal.behaviors because it doesn't need to
   // run each time ajax gets called.
   window.parent.postMessage('ready', window.origin);
@@ -8,20 +12,26 @@
   Drupal.behaviors.ochaAiChatForm = {
     attach: function (context, settings) {
       var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
-
-      // Scroll to bottom of chat container. We can't use smooth scrolling to
-      // create a convincing effect without storing and calculating the position
-      // from before the ajax submission, so we immediately set it to the bottom
-      // so that any new content is prominently visible neat the text input.
-      chatContainer.scrollTop = chatContainer.scrollHeight;
-
-      // Custom actions when submit is pressed. Each time ajax finishes, the whole
-      // chat history will be re-rendered so we can temporarily inject whatever we
-      // like and it will get cleaned up.
       var submitButton = document.querySelector('[data-drupal-selector="edit-submit"]');
-      // TODO: will this work on mobile or do we need to attach the listener to
-      // separate events? e.g. touchend
-      submitButton.addEventListener('mousedown', event => {
+
+      // Do some calculations to decide where to start our smooth scroll.
+      if (oldScrollHeight) {
+        var chatHeight = chatContainer.getBoundingClientRect().height;
+        var smoothScrollStart = oldScrollHeight - chatHeight;
+
+        // Jump to where the bottom of the previous container was before the DOM
+        // got updated. From there, we smooth-scroll to the bottom.
+        chatContainer.scrollTo({top: smoothScrollStart, behavior: 'instant'});
+        chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
+      }
+      else {
+        chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
+      }
+
+      // Upate UI when submit is pressed. Each time ajax finishes, the
+      // whole chat history will be re-inserted into the DOM. That means we can
+      // temporarily inject whatever we like and it will get cleaned up for us.
+      function chatSend (event) {
         var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
         var chatResult = Drupal.behaviors.ochaAiChatUtils.createElement('div', {
           'class': 'ocha-ai-chat-result',
@@ -33,9 +43,8 @@
           'class': 'chat__q chat__q--loading',
         }, {});
         var questionDt = Drupal.behaviors.ochaAiChatUtils.createElement('dt', {
-            'class': 'visually-hidden',
-          }, 'Question'
-        );
+          'class': 'visually-hidden',
+        }, 'Question');
         var questionValue = document.querySelector('[data-drupal-selector="edit-question"]').value;
         var questionDd = Drupal.behaviors.ochaAiChatUtils.createElement('dd', {}, questionValue);
 
@@ -53,8 +62,17 @@
           // the continer can be scrolled to begin with, so in practice the
           // first one never has a smooth scroll.
           chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
+
+          // Store the scroll position so that we can attempt to smooth-scroll
+          // when the form reloads with new data attached.
+          oldScrollHeight = chatContainer.scrollHeight;
         }, 200);
-      });
+      };
+
+      // All the input modes!
+      submitButton.addEventListener('mousedown', chatSend);
+      submitButton.addEventListener('keydown', chatSend);
+      submitButton.addEventListener('touchend', chatSend);
     },
   };
 

--- a/components/chat-form/chat-form.js
+++ b/components/chat-form/chat-form.js
@@ -74,9 +74,14 @@
       };
 
       // All the input modes!
-      submitButton.addEventListener('mousedown', chatSend);
-      submitButton.addEventListener('keydown', chatSend);
       submitButton.addEventListener('touchend', chatSend);
+      submitButton.addEventListener('mousedown', chatSend);
+      submitButton.addEventListener('keydown', function(ev) {
+        // First check that the [Enter] key is being pressed.
+        if (ev.keyCode === 13) {
+          chatSend(ev);
+        }
+      });
     },
   };
 

--- a/components/chat-popup/chat-popup.css
+++ b/components/chat-popup/chat-popup.css
@@ -34,8 +34,8 @@
 }
 .data-ocha-ai-chat-chat-popup__button--close {
   z-index: 10001;
-  top: 36px;
-  right: 36px;
+  top: 17px;
+  right: 16px;
   bottom: auto;
   width: 18px;
   height: 18px;
@@ -91,4 +91,11 @@
   border: 3px solid #999;
   border-top-color: #333;
   border-radius: 50%;
+}
+
+/**
+ * Modifier to lock scrolling of main page while popup is opened.
+ */
+.is--scroll-locked {
+  overflow: hidden;
 }

--- a/components/chat-popup/chat-popup.css
+++ b/components/chat-popup/chat-popup.css
@@ -6,6 +6,16 @@
   width: 100vw;
   height: 100vh;
   background: white;
+  box-shadow: 0 4px 6px 4px rgba(0, 0, 0, 0.2);
+
+  @media screen and (min-width: 610px) {
+    right: 24px;
+    width: 480px;
+    height: 80vh;
+    max-height: 680px;
+    border: 2px solid black;
+    border-bottom: none;
+  }
 }
 
 .ocha-ai-chat-chat-popup__iframe {
@@ -14,8 +24,10 @@
   border: none;
 }
 
-.data-ocha-ai-chat-chat-popup__button {
+/* Open button */
+.data-ocha-ai-chat-chat-popup__button-open {
   position: fixed;
+  z-index: 9999;
   right: 24px;
   bottom: 24px;
   width: 64px;
@@ -23,32 +35,29 @@
   border: none;
   background: var(--rw-icons--chat--chat--64--dark-blue);
 }
-.data-ocha-ai-chat-chat-popup__button:active,
-.data-ocha-ai-chat-chat-popup__button:focus,
-.data-ocha-ai-chat-chat-popup__button:hover {
+
+.data-ocha-ai-chat-chat-popup__button-open:active,
+.data-ocha-ai-chat-chat-popup__button-open:focus,
+.data-ocha-ai-chat-chat-popup__button-open:hover {
   background: var(--rw-icons--chat--chat--64--dark-red);
 }
-.data-ocha-ai-chat-chat-popup__button--close {
+
+/* Close button */
+.data-ocha-ai-chat-chat-popup__button-close {
+  position: absolute;
   z-index: 10001;
   top: 17px;
   right: 16px;
-  bottom: auto;
   width: 18px;
   height: 18px;
+  border: none;
   background: var(--rw-icons--common--close--18--white);
 }
-.data-ocha-ai-chat-chat-popup__button--close:active,
-.data-ocha-ai-chat-chat-popup__button--close:focus,
-.data-ocha-ai-chat-chat-popup__button--close:hover {
+
+.data-ocha-ai-chat-chat-popup__button-close:active,
+.data-ocha-ai-chat-chat-popup__button-close:focus,
+.data-ocha-ai-chat-chat-popup__button-close:hover {
   background: var(--rw-icons--common--close--18--dark-red);
-}
-.data-ocha-ai-chat-chat-popup__button__label {
-  position: absolute !important;
-  overflow: hidden;
-  clip: rect(1px, 1px, 1px, 1px);
-  width: 1px;
-  height: 1px;
-  word-wrap: normal;
 }
 
 /**
@@ -62,6 +71,7 @@
     transform: rotate(360deg);
   }
 }
+
 .ocha-ai-chat-chat-popup-loading:before {
   position: absolute;
   z-index: 10000;
@@ -72,6 +82,7 @@
   content: "";
   background-color: rgba(0, 0, 0, 0.2);
 }
+
 .ocha-ai-chat-chat-popup-loading:after {
   position: absolute;
   z-index: 10001;
@@ -92,6 +103,10 @@
 /**
  * Modifier to lock scrolling of main page while popup is opened.
  */
-.is--scroll-locked {
+.is--mobile-scroll-locked {
   overflow: hidden;
+
+  @media screen and (min-width: 610px) {
+    overflow: initial;
+  }
 }

--- a/components/chat-popup/chat-popup.css
+++ b/components/chat-popup/chat-popup.css
@@ -10,6 +10,7 @@
   background: white;
   box-shadow: 0 0 4px 4px rgba(0, 0, 0, 0.2);
 }
+
 .ocha-ai-chat-chat-popup__iframe {
   width: 100%;
   height: 100%;
@@ -38,7 +39,7 @@
   bottom: auto;
   width: 18px;
   height: 18px;
-  background: var(--rw-icons--common--close--18--dark-blue);
+  background: var(--rw-icons--common--close--18--white);
 }
 .data-ocha-ai-chat-chat-popup__button--close:active,
 .data-ocha-ai-chat-chat-popup__button--close:focus,

--- a/components/chat-popup/chat-popup.css
+++ b/components/chat-popup/chat-popup.css
@@ -1,21 +1,17 @@
 .ocha-ai-chat-chat-popup {
   position: fixed;
   z-index: 10000;
-  top: 24px;
-  right: 24px;
-  width: 30vw;
-  height: calc(100vh - 48px);
-  border: 2px solid black;
-  border-radius: 9px;
+  bottom: 0;
+  right: 0;
+  width: 100vw;
+  height: 100vh;
   background: white;
-  box-shadow: 0 0 4px 4px rgba(0, 0, 0, 0.2);
 }
 
 .ocha-ai-chat-chat-popup__iframe {
   width: 100%;
   height: 100%;
   border: none;
-  border-radius: 6px;
 }
 
 .data-ocha-ai-chat-chat-popup__button {

--- a/components/chat-popup/chat-popup.css
+++ b/components/chat-popup/chat-popup.css
@@ -6,7 +6,7 @@
   width: 30vw;
   height: calc(100vh - 48px);
   border: 2px solid black;
-  border-radius: 6px;
+  border-radius: 9px;
   background: white;
   box-shadow: 0 0 4px 4px rgba(0, 0, 0, 0.2);
 }

--- a/components/chat-popup/chat-popup.js
+++ b/components/chat-popup/chat-popup.js
@@ -1,50 +1,5 @@
 (function () {
-
   'use strict';
-
-  /**
-   * Create a DOM element with the given attributes and content.
-   *
-   * @param {String} tag
-   *   The element tag.
-   * @param {Object} attributes
-   *   Map of attribute names and values.
-   * @param {String|Element|Array} content
-   *   Either a text, an DOM element or an array of DOM elements.
-   *
-   * @return Element
-   *   The created DOM element.
-   */
-  function createElement(tag, attributes, content) {
-    const element = document.createElement(tag);
-    if (typeof attributes === 'object') {
-      for (const attribute in attributes) {
-        if (attributes.hasOwnProperty(attribute)) {
-          let value = attributes[attribute];
-          element.setAttribute(attribute, Array.isArray(value) ? value.join(' ') : value);
-        }
-      }
-    }
-    switch (typeof content) {
-      case 'string':
-        element.appendChild(document.createTextNode(content));
-        break;
-
-      case 'object':
-        // Assume it's is DOM element.
-        if (content.nodeType) {
-          element.appendChild(content);
-        }
-        // Assume it's a list of DOM elements.
-        else if (typeof content.length !== 'undefined') {
-          for (var i = 0, l = content.length; i < l; i++) {
-            element.appendChild(content[i]);
-          }
-        }
-        break;
-    }
-    return element;
-  }
 
   function processPopup(popup) {
     // Mark the popup as processed so the following code runs only once.
@@ -56,7 +11,7 @@
 
     const link = popup.querySelector('a');
 
-    const iframe = createElement('iframe', {
+    const iframe = Drupal.behaviors.ochaAiChatUtils.createElement('iframe', {
       'class': 'ocha-ai-chat-chat-popup__iframe',
       'data-src': link.href
     });
@@ -72,10 +27,10 @@
     link.replaceWith(iframe);
 
     // Replace the link with a button to open the chat window.
-    const openButton = createElement('button', {
+    const openButton = Drupal.behaviors.ochaAiChatUtils.createElement('button', {
       'type': 'button',
       'class': 'data-ocha-ai-chat-chat-popup__button-open'
-    }, createElement('span', {
+    }, Drupal.behaviors.ochaAiChatUtils.createElement('span', {
       'class': 'data-ocha-ai-chat-chat-popup__button-open__label visually-hidden'
     }, Drupal.t('Open chat')));
 
@@ -94,10 +49,10 @@
 
     // Create a separate close button that sits inside the <section> and can
     // be more easily positioned in all viewport sizes.
-    const closeButton = createElement('button', {
+    const closeButton = Drupal.behaviors.ochaAiChatUtils.createElement('button', {
       'type': 'button',
       'class': 'data-ocha-ai-chat-chat-popup__button-close'
-    }, createElement('span', {
+    }, Drupal.behaviors.ochaAiChatUtils.createElement('span', {
       'class': 'data-ocha-ai-chat-chat-popup__button-close__label visually-hidden'
     }, Drupal.t('Close chat')));
 
@@ -113,7 +68,7 @@
   /**
    * Drupal behavior for the chat popup.
    */
-  Drupal.behaviors.ochaAiChat = {
+  Drupal.behaviors.ochaAiChatPopup = {
     attach: function (context, settings) {
       // Get the "Ask ReliefWeb" popup.
       const popup = context.querySelector('[data-ocha-ai-chat-chat-popup]');

--- a/components/chat-popup/chat-popup.js
+++ b/components/chat-popup/chat-popup.js
@@ -71,27 +71,43 @@
     // Replace the link with the iframe.
     link.replaceWith(iframe);
 
-    // Replace the link with a button.
-    const button = createElement('button', {
+    // Replace the link with a button to open the chat window.
+    const openButton = createElement('button', {
       'type': 'button',
-      'class': 'data-ocha-ai-chat-chat-popup__button'
+      'class': 'data-ocha-ai-chat-chat-popup__button-open'
     }, createElement('span', {
-      'class': 'data-ocha-ai-chat-chat-popup__button__label'
-    }, Drupal.t('Toggle chat')));
+      'class': 'data-ocha-ai-chat-chat-popup__button-open__label visually-hidden'
+    }, Drupal.t('Open chat')));
 
-    popup.before(button);
+    popup.before(openButton);
 
-    // Show the chat popup.
-    button.addEventListener('click', event => {
+    // Clicking/tapping will show the chat popup.
+    openButton.addEventListener('click', event => {
       if (!iframe.src) {
         popup.classList.add('ocha-ai-chat-chat-popup-loading');
         iframe.src = iframe.getAttribute('data-src');
       }
 
-      popup.toggleAttribute('hidden');
-      button.classList.toggle('data-ocha-ai-chat-chat-popup__button--close');
-      document.documentElement.classList.toggle('is--scroll-locked');
+      popup.removeAttribute('hidden');
+      document.documentElement.classList.add('is--mobile-scroll-locked');
     });
+
+    // Create a separate close button that sits inside the <section> and can
+    // be more easily positioned in all viewport sizes.
+    const closeButton = createElement('button', {
+      'type': 'button',
+      'class': 'data-ocha-ai-chat-chat-popup__button-close'
+    }, createElement('span', {
+      'class': 'data-ocha-ai-chat-chat-popup__button-close__label visually-hidden'
+    }, Drupal.t('Close chat')));
+
+    // Clicking/tapping will hide the chat popup.
+    closeButton.addEventListener('click', event => {
+      popup.setAttribute('hidden', '');
+      document.documentElement.classList.remove('is--mobile-scroll-locked');
+    });
+
+    popup.prepend(closeButton);
   }
 
   /**

--- a/components/chat-popup/chat-popup.js
+++ b/components/chat-popup/chat-popup.js
@@ -77,7 +77,7 @@
       'class': 'data-ocha-ai-chat-chat-popup__button'
     }, createElement('span', {
       'class': 'data-ocha-ai-chat-chat-popup__button__label'
-    }, Drupal.t('Open chat')));
+    }, Drupal.t('Toggle chat')));
 
     popup.before(button);
 
@@ -87,8 +87,10 @@
         popup.classList.add('ocha-ai-chat-chat-popup-loading');
         iframe.src = iframe.getAttribute('data-src');
       }
+
       popup.toggleAttribute('hidden');
       button.classList.toggle('data-ocha-ai-chat-chat-popup__button--close');
+      document.documentElement.classList.toggle('is--scroll-locked');
     });
   }
 

--- a/components/chat-popup/chat-popup.js
+++ b/components/chat-popup/chat-popup.js
@@ -50,7 +50,7 @@
     // Mark the popup as processed so the following code runs only once.
     popup.setAttribute('data-ocha-ai-chat-chat-popup-processed', '');
     popup.setAttribute('aria-modal', true);
-    popup.setAttribute('aria-label', Drupal.t('Ask the documents'));
+    popup.setAttribute('aria-label', Drupal.t('Ask ReliefWeb'));
     popup.setAttribute('role', 'dialog');
     popup.setAttribute('hidden', '');
 
@@ -99,7 +99,7 @@
    */
   Drupal.behaviors.ochaAiChat = {
     attach: function (context, settings) {
-      // Get the "Ask the documents" popup.
+      // Get the "Ask ReliefWeb" popup.
       const popup = context.querySelector('[data-ocha-ai-chat-chat-popup]');
 
       // Convert to a popup dialog.

--- a/components/chat-utils/chat-utils.js
+++ b/components/chat-utils/chat-utils.js
@@ -1,0 +1,50 @@
+(function () {
+  'use strict';
+
+  Drupal.behaviors.ochaAiChatUtils = {
+    /**
+     * Create a DOM element with the given attributes and content.
+     *
+     * @param {String} tag
+     *   The element tag.
+     * @param {Object} attributes
+     *   Map of attribute names and values.
+     * @param {String|Element|Array} content
+     *   Either a text, an DOM element or an array of DOM elements.
+     *
+     * @return Element
+     *   The created DOM element.
+     */
+    createElement: function(tag, attributes, content) {
+      const element = document.createElement(tag);
+      if (typeof attributes === 'object') {
+        for (const attribute in attributes) {
+          if (attributes.hasOwnProperty(attribute)) {
+            let value = attributes[attribute];
+            element.setAttribute(attribute, Array.isArray(value) ? value.join(' ') : value);
+          }
+        }
+      }
+      switch (typeof content) {
+        case 'string':
+          element.appendChild(document.createTextNode(content));
+          break;
+
+        case 'object':
+          // Assume it's is DOM element.
+          if (content.nodeType) {
+            element.appendChild(content);
+          }
+          // Assume it's a list of DOM elements.
+          else if (typeof content.length !== 'undefined') {
+            for (var i = 0, l = content.length; i < l; i++) {
+              element.appendChild(content[i]);
+            }
+          }
+          break;
+      }
+      return element;
+    }
+  };
+
+})();

--- a/ocha_ai_chat.libraries.yml
+++ b/ocha_ai_chat.libraries.yml
@@ -1,3 +1,7 @@
+chat.utils:
+  js:
+    components/chat-utils/chat-utils.js: {}
+
 chat.form:
   css:
     theme:
@@ -6,6 +10,7 @@ chat.form:
     components/chat-form/chat-form.js: {}
   dependencies:
     - ocha_ai_chat/rw-icons
+    - ocha_ai_chat/chat.utils
 
 chat.popup:
   css:
@@ -15,6 +20,7 @@ chat.popup:
     components/chat-popup/chat-popup.js: {}
   dependencies:
     - ocha_ai_chat/rw-icons
+    - ocha_ai_chat/chat.utils
 
 logs.form:
   css:

--- a/ocha_ai_chat.libraries.yml
+++ b/ocha_ai_chat.libraries.yml
@@ -9,6 +9,8 @@ chat.form:
   js:
     components/chat-form/chat-form.js: {}
   dependencies:
+    - core/drupal
+    - core/drupal.debounce
     - ocha_ai_chat/rw-icons
     - ocha_ai_chat/chat.utils
 

--- a/ocha_ai_chat.module
+++ b/ocha_ai_chat.module
@@ -19,7 +19,7 @@ function ocha_ai_chat_theme(): array {
         // Section attributes.
         'attributes' => NULL,
         // Section title.
-        'title' => t('Chat with documents'),
+        'title' => t('Ask ReliefWeb'),
         // Title attributes.
         'title_attributes' => NULL,
         // Link to the chat form.

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -96,9 +96,9 @@ class OchaAiChatChatForm extends FormBase {
   public function getPageTitle(?bool $popup = NULL): TranslatableMarkup {
     $limit = $this->getRequest()?->query?->get('limit');
     if (isset($limit) && $limit == 1) {
-      return $this->t('Ask the document');
+      return $this->t('Ask ReliefWeb');
     }
-    return $this->t('Ask the documents');
+    return $this->t('Ask ReliefWeb');
   }
 
   /**
@@ -180,7 +180,7 @@ class OchaAiChatChatForm extends FormBase {
     $form['advanced']['completion_plugin_id'] = [
       '#type' => 'select',
       '#title' => $this->t('AI service'),
-      '#description' => $this->t('Select the AI service to use to generate the answer.'),
+      '#description' => $this->t('Select which AI service will generate the answer.'),
       '#options' => $completion_options,
       '#default_value' => $completion_default,
       '#required' => TRUE,

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -234,7 +234,7 @@ class OchaAiChatChatForm extends FormBase {
       '#title' => $this->t('Enter your question'),
       '#title_display' => 'invisible',
       '#default_value' => $form_state->getValue('question') ?? NULL,
-      '#description' => $this->t('Ex: How many people are in need of humanitarian assistance in <em>location</em> due to the <em>event</em> that started on <em>date</em>?'),
+      '#placeholder' => $this->t('Ex: How many people are in need of nutritional assistance?'),
       '#rows' => 2,
     ];
 

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -268,7 +268,7 @@ class OchaAiChatChatForm extends FormBase {
 
     $form['question'] = [
       '#type' => 'textarea',
-      '#title' => $this->t('Question'),
+      '#title' => $this->t('Enter your question'),
       '#title_display' => 'invisible',
       '#default_value' => $form_state->getValue('question') ?? NULL,
       '#description' => $this->t('Ex: How many people are in need of humanitarian assistance in <em>location</em> due to the <em>event</em> that started on <em>date</em>?'),

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -107,44 +107,6 @@ class OchaAiChatChatForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state, ?bool $popup = NULL): array {
     $defaults = $this->ochaAiChat->getSettings();
 
-    /*
-    // Display the form instruction config.
-    if (!empty($defaults['form']['instructions']['value'])) {
-      $hide = $form_state->getValue([
-        'instructions',
-        'content',
-        'hide',
-      ], $this->database
-        ->select('ocha_ai_chat_preferences', 't')
-        ->fields('t', ['hide_instructions'])
-        ->condition('t.uid', $this->currentUser->id())
-        ->execute()
-        ?->fetchField()
-      );
-      $form['instructions'] = [
-        '#type' => 'details',
-        '#prefix' => '<div id="ocha-ai-chat-instructions" class="ocha-ai-chat-chat-form__instructions">',
-        '#suffix' => '</div>',
-        '#title' => $this->t('Instructions'),
-        '#open' => !empty($hide) ? FALSE : TRUE,
-        '#tree' => TRUE,
-      ];
-      $form['instructions']['content']['hide'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Do not show instructions anymore'),
-        '#default_value' => !empty($hide),
-        '#limit_validation_errors' => [
-          ['instructions', 'content', 'hide'],
-        ],
-        '#ajax' => [
-          'callback' => [$this, 'hideInstructions'],
-          'wrapper' => 'ocha-ai-chat-instructions',
-          'disable-refocus' => TRUE,
-        ],
-      ];
-    }
-    */
-
     // Add the source widget.
     $form = $this->ochaAiChat->getSourcePlugin()->getSourceWidget($form, $form_state, $defaults);
     if (isset($form['source'])) {

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -208,7 +208,7 @@ class OchaAiChatChatForm extends FormBase {
       ];
       $form['chat'][$index]['result'] = [
         '#type' => 'inline_template',
-        '#template' => '<dl><dt>Question</dt><dd>{{ question }}</dd><dt>Answer</dt><dd>{{ answer }}</dd>{% if references %}<dt>References</dt><dd>{{ references }}</dd>{% endif %}</dl>',
+        '#template' => '<dl><div class="chat_q"><dt class="visually-hidden">Question</dt><dd>{{ question }}</dd></div><div class="chat_a"><dt class="visually-hidden">Answer</dt><dd>{{ answer }}</dd></div>{% if references %}<div class="chat_refs"><dt>References</dt><dd>{{ references }}</dd></div>{% endif %}</dl>',
         '#context' => [
           'question' => $record['question'],
           'answer' => $record['answer'],
@@ -474,6 +474,7 @@ class OchaAiChatChatForm extends FormBase {
         ],
       ];
     }
+
     return [
       '#theme' => 'item_list',
       '#items' => $items,
@@ -482,6 +483,7 @@ class OchaAiChatChatForm extends FormBase {
         'class' => [
           'ocha-ai-chat-reference-list',
         ],
+        'role' => 'list',
       ],
     ];
   }

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -107,42 +107,43 @@ class OchaAiChatChatForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state, ?bool $popup = NULL): array {
     $defaults = $this->ochaAiChat->getSettings();
 
+    /*
     // Display the form instruction config.
-    // if (!empty($defaults['form']['instructions']['value'])) {
-    //   $hide = $form_state->getValue([
-    //     'instructions',
-    //     'content',
-    //     'hide',
-    //   ], $this->database
-    //     ->select('ocha_ai_chat_preferences', 't')
-    //     ->fields('t', ['hide_instructions'])
-    //     ->condition('t.uid', $this->currentUser->id())
-    //     ->execute()
-    //     ?->fetchField()
-    //   );
-
-    //   $form['instructions'] = [
-    //     '#type' => 'details',
-    //     '#prefix' => '<div id="ocha-ai-chat-instructions" class="ocha-ai-chat-chat-form__instructions">',
-    //     '#suffix' => '</div>',
-    //     '#title' => $this->t('Instructions'),
-    //     '#open' => !empty($hide) ? FALSE : TRUE,
-    //     '#tree' => TRUE,
-    //   ];
-    //   $form['instructions']['content']['hide'] = [
-    //     '#type' => 'checkbox',
-    //     '#title' => $this->t('Do not show instructions anymore'),
-    //     '#default_value' => !empty($hide),
-    //     '#limit_validation_errors' => [
-    //       ['instructions', 'content', 'hide'],
-    //     ],
-    //     '#ajax' => [
-    //       'callback' => [$this, 'hideInstructions'],
-    //       'wrapper' => 'ocha-ai-chat-instructions',
-    //       'disable-refocus' => TRUE,
-    //     ],
-    //   ];
-    // }
+    if (!empty($defaults['form']['instructions']['value'])) {
+      $hide = $form_state->getValue([
+        'instructions',
+        'content',
+        'hide',
+      ], $this->database
+        ->select('ocha_ai_chat_preferences', 't')
+        ->fields('t', ['hide_instructions'])
+        ->condition('t.uid', $this->currentUser->id())
+        ->execute()
+        ?->fetchField()
+      );
+      $form['instructions'] = [
+        '#type' => 'details',
+        '#prefix' => '<div id="ocha-ai-chat-instructions" class="ocha-ai-chat-chat-form__instructions">',
+        '#suffix' => '</div>',
+        '#title' => $this->t('Instructions'),
+        '#open' => !empty($hide) ? FALSE : TRUE,
+        '#tree' => TRUE,
+      ];
+      $form['instructions']['content']['hide'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Do not show instructions anymore'),
+        '#default_value' => !empty($hide),
+        '#limit_validation_errors' => [
+          ['instructions', 'content', 'hide'],
+        ],
+        '#ajax' => [
+          'callback' => [$this, 'hideInstructions'],
+          'wrapper' => 'ocha-ai-chat-instructions',
+          'disable-refocus' => TRUE,
+        ],
+      ];
+    }
+    */
 
     // Add the source widget.
     $form = $this->ochaAiChat->getSourcePlugin()->getSourceWidget($form, $form_state, $defaults);

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -234,7 +234,7 @@ class OchaAiChatChatForm extends FormBase {
       '#title' => $this->t('Enter your question'),
       '#title_display' => 'invisible',
       '#default_value' => $form_state->getValue('question') ?? NULL,
-      '#placeholder' => $this->t('Ex: How many people are in need of nutritional assistance?'),
+      '#placeholder' => $this->t('Ex: How many people are in need of food assistance?'),
       '#rows' => 2,
     ];
 

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -213,7 +213,7 @@ class OchaAiChatChatForm extends FormBase {
       ];
       $form['chat'][$index]['result'] = [
         '#type' => 'inline_template',
-        '#template' => '<dl><div class="chat_q"><dt class="visually-hidden">Question</dt><dd>{{ question }}</dd></div><div class="chat_a"><dt class="visually-hidden">Answer</dt><dd>{{ answer }}</dd></div>{% if references %}<div class="chat_refs"><dt>References</dt><dd>{{ references }}</dd></div>{% endif %}</dl>',
+        '#template' => '<dl class="chat"><div class="chat__q"><dt class="visually-hidden">Question</dt><dd>{{ question }}</dd></div><div class="chat__a"><dt class="visually-hidden">Answer</dt><dd>{{ answer }}</dd></div>{% if references %}<div class="chat__refs"><dt>References</dt><dd>{{ references }}</dd></div>{% endif %}</dl>',
         '#context' => [
           'question' => $record['question'],
           'answer' => $record['answer'],

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -191,7 +191,8 @@ class OchaAiChatChatForm extends FormBase {
     $form['chat'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('History'),
-      '#access' => !empty($history),
+      '#title_display' => 'invisible',
+      '#access' => TRUE,
       '#tree' => TRUE,
     ];
     $form['history'] = [
@@ -264,6 +265,7 @@ class OchaAiChatChatForm extends FormBase {
     $form['question'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Question'),
+      '#title_display' => 'invisible',
       '#default_value' => $form_state->getValue('question') ?? NULL,
       '#description' => $this->t('Ex: How many people are in need of humanitarian assistance in <em>location</em> due to the <em>event</em> that started on <em>date</em>?'),
       '#rows' => 2,

--- a/src/Form/OchaAiChatChatForm.php
+++ b/src/Form/OchaAiChatChatForm.php
@@ -107,47 +107,42 @@ class OchaAiChatChatForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state, ?bool $popup = NULL): array {
     $defaults = $this->ochaAiChat->getSettings();
 
-    // Display the form instructions.
-    if (!empty($defaults['form']['instructions']['value'])) {
-      $hide = $form_state->getValue([
-        'instructions',
-        'content',
-        'hide',
-      ], $this->database
-        ->select('ocha_ai_chat_preferences', 't')
-        ->fields('t', ['hide_instructions'])
-        ->condition('t.uid', $this->currentUser->id())
-        ->execute()
-        ?->fetchField()
-      );
+    // Display the form instruction config.
+    // if (!empty($defaults['form']['instructions']['value'])) {
+    //   $hide = $form_state->getValue([
+    //     'instructions',
+    //     'content',
+    //     'hide',
+    //   ], $this->database
+    //     ->select('ocha_ai_chat_preferences', 't')
+    //     ->fields('t', ['hide_instructions'])
+    //     ->condition('t.uid', $this->currentUser->id())
+    //     ->execute()
+    //     ?->fetchField()
+    //   );
 
-      $form['instructions'] = [
-        '#type' => 'details',
-        '#prefix' => '<div id="ocha-ai-chat-instructions" class="ocha-ai-chat-chat-form__instructions">',
-        '#suffix' => '</div>',
-        '#title' => $this->t('Instructions'),
-        '#open' => !empty($hide) ? FALSE : TRUE,
-        '#tree' => TRUE,
-      ];
-      $form['instructions']['content'] = [
-        '#type' => 'processed_text',
-        '#text' => $defaults['form']['instructions']['value'],
-        '#format' => $defaults['form']['instructions']['format'],
-      ];
-      $form['instructions']['content']['hide'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Do not show instructions anymore'),
-        '#default_value' => !empty($hide),
-        '#limit_validation_errors' => [
-          ['instructions', 'content', 'hide'],
-        ],
-        '#ajax' => [
-          'callback' => [$this, 'hideInstructions'],
-          'wrapper' => 'ocha-ai-chat-instructions',
-          'disable-refocus' => TRUE,
-        ],
-      ];
-    }
+    //   $form['instructions'] = [
+    //     '#type' => 'details',
+    //     '#prefix' => '<div id="ocha-ai-chat-instructions" class="ocha-ai-chat-chat-form__instructions">',
+    //     '#suffix' => '</div>',
+    //     '#title' => $this->t('Instructions'),
+    //     '#open' => !empty($hide) ? FALSE : TRUE,
+    //     '#tree' => TRUE,
+    //   ];
+    //   $form['instructions']['content']['hide'] = [
+    //     '#type' => 'checkbox',
+    //     '#title' => $this->t('Do not show instructions anymore'),
+    //     '#default_value' => !empty($hide),
+    //     '#limit_validation_errors' => [
+    //       ['instructions', 'content', 'hide'],
+    //     ],
+    //     '#ajax' => [
+    //       'callback' => [$this, 'hideInstructions'],
+    //       'wrapper' => 'ocha-ai-chat-instructions',
+    //       'disable-refocus' => TRUE,
+    //     ],
+    //   ];
+    // }
 
     // Add the source widget.
     $form = $this->ochaAiChat->getSourcePlugin()->getSourceWidget($form, $form_state, $defaults);
@@ -198,6 +193,15 @@ class OchaAiChatChatForm extends FormBase {
     $form['history'] = [
       '#type' => 'hidden',
       '#value' => $history,
+    ];
+
+    // Output instructions as part of scrollable chat history.
+    $form['chat']['content'] = [
+      '#type' => 'processed_text',
+      '#prefix' => '<div id="ocha-ai-chat-instructions" class="ocha-ai-chat-chat-form__instructions">',
+      '#suffix' => '</div>',
+      '#text' => $defaults['form']['instructions']['value'],
+      '#format' => $defaults['form']['instructions']['format'],
     ];
 
     foreach (json_decode($history, TRUE) ?? [] as $index => $record) {


### PR DESCRIPTION
# RW-857

Makes the chat look more like a modern messaging app. Optional companion PR: https://github.com/UN-OCHA/rwint9-site/pull/719

- Name changed to Ask ReliefWeb.
- Added a separate close button for a11y/cosmetics' sake. Each button has a dedicated label "open chat" / "close chat" and on desktop it was far easier to position a button inside the `<section>` rather than as a sibling.
- Full-bleed on mobile, will switch once the desktop dimensions leave enough room to see parts of the webpage. At smaller screens it's as obtrusive as a modal.
- Chat contents now look like a messaging app such as SMS or WhatsApp. None of the labels have been removed, it's still screen-reader friendly.
- The standard Drupal ajax is still there, but it will insert your question into the DOM while the LLM churns. The ajax throbber got nudged into the message area while the request is in flight.
- I did my best to smooth-scroll everything into view so that it feels "normal" for a chat UI.
- At Emma's direction, the feedback widget was left as-is. I would have liked to convert it to thumbs up/down, but that will happen some other time.